### PR TITLE
Expose `buildRegex()`

### DIFF
--- a/lib/lucene_to_regex.js
+++ b/lib/lucene_to_regex.js
@@ -36,6 +36,7 @@ const buildRegex = (ast, negate) => {
 module.exports = {
   parse: lucene.parse,
   toString: lucene.toString,
+  buildRegex: buildRegex,
   toRegex: (query, flag) => {
     const ast = lucene.parse(query)
     const regex = `^${buildRegex(ast)}.*$`


### PR DESCRIPTION
This allows me to parse my own AST from Lucene, then modify the tree before passing it to buildRegex(). This is needed so I can have more control over the operator, such as handling different default operators.